### PR TITLE
fix: macOS compatibility — install.sh, issue-parser.sh, and worktree workspace hook

### DIFF
--- a/hooks/callbacks/validate-workspace-path.sh
+++ b/hooks/callbacks/validate-workspace-path.sh
@@ -86,19 +86,6 @@ elif [[ -n "$workspace_abs" ]]; then
     ralph_dir_abs=$(realpath "$workspace/../../.." 2>/dev/null)
 fi
 
-# Detect worktree -> resolve original repo as additional allowed path.
-# Git worktrees have a .git *file* (not directory) pointing back to the
-# main repo. Claude Code follows this reference and resolves its project
-# root to the original repo, causing tool paths to point there instead of
-# the worktree. We allow those paths so agents are not blocked.
-original_repo_abs=""
-if [[ -f "$workspace/.git" ]]; then
-    original_repo_abs=$(git -C "$workspace" rev-parse --show-superproject-working-tree 2>/dev/null)
-    if [[ -z "$original_repo_abs" ]]; then
-        original_repo_abs=$(git -C "$workspace" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git.*$||')
-    fi
-fi
-
 # Helper function to check if path is in blocked worker_dir locations
 # Returns 0 if blocked, 1 if allowed
 #
@@ -176,11 +163,6 @@ validate_path() {
 
     # 1. workspace (worker_dir/workspace) - always allowed
     if [[ "$abs_path" == "$workspace_abs"* ]]; then
-        return 0
-    fi
-
-    # 1b. original repo (when workspace is a worktree) - allowed
-    if [[ -n "$original_repo_abs" && "$abs_path" == "$original_repo_abs"* ]]; then
         return 0
     fi
 

--- a/lib/backend/claude/claude-backend.sh
+++ b/lib/backend/claude/claude-backend.sh
@@ -47,11 +47,16 @@ runtime_backend_init() {
 # =============================================================================
 
 # Invoke Claude CLI with auth token scoped only to that process
+#
+# Sets CLAUDE_PROJECT_DIR to PWD when not already set, ensuring Claude
+# uses the worktree directory (not the original repo) as its project root.
+# run_agent_once() does cd "$workspace" before calling this, so PWD is correct.
 runtime_backend_invoke() {
+    local _project_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
     if [ -n "${_WIGGUM_AUTH_TOKEN:-}" ]; then
-        ANTHROPIC_AUTH_TOKEN="$_WIGGUM_AUTH_TOKEN" "$CLAUDE" "$@"
+        ANTHROPIC_AUTH_TOKEN="$_WIGGUM_AUTH_TOKEN" CLAUDE_PROJECT_DIR="$_project_dir" "$CLAUDE" "$@"
     else
-        "$CLAUDE" "$@"
+        CLAUDE_PROJECT_DIR="$_project_dir" "$CLAUDE" "$@"
     fi
 }
 

--- a/lib/github/issue-parser.sh
+++ b/lib/github/issue-parser.sh
@@ -208,13 +208,13 @@ github_issue_parse_body_json() {
     local description="" priority="" complexity="" dependencies=""
     local scope="" out_of_scope="" acceptance_criteria=""
 
-    [ -f "$tmp_dir/description" ] && description=$(sed '/./,$!d' "$tmp_dir/description" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
+    [ -f "$tmp_dir/description" ] && description=$(sed '/./,$!d' "$tmp_dir/description" | sed -e ':a' -e '/^[[:space:]]*$/{' -e '$d' -e 'N' -e 'ba' -e '}')
     [ -f "$tmp_dir/priority" ] && priority=$(cat "$tmp_dir/priority")
     [ -f "$tmp_dir/complexity" ] && complexity=$(cat "$tmp_dir/complexity")
     [ -f "$tmp_dir/dependencies" ] && dependencies=$(cat "$tmp_dir/dependencies")
-    [ -f "$tmp_dir/scope" ] && scope=$(sed '/./,$!d' "$tmp_dir/scope" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
-    [ -f "$tmp_dir/out_of_scope" ] && out_of_scope=$(sed '/./,$!d' "$tmp_dir/out_of_scope" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
-    [ -f "$tmp_dir/acceptance_criteria" ] && acceptance_criteria=$(sed '/./,$!d' "$tmp_dir/acceptance_criteria" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
+    [ -f "$tmp_dir/scope" ] && scope=$(sed '/./,$!d' "$tmp_dir/scope" | sed -e ':a' -e '/^[[:space:]]*$/{' -e '$d' -e 'N' -e 'ba' -e '}')
+    [ -f "$tmp_dir/out_of_scope" ] && out_of_scope=$(sed '/./,$!d' "$tmp_dir/out_of_scope" | sed -e ':a' -e '/^[[:space:]]*$/{' -e '$d' -e 'N' -e 'ba' -e '}')
+    [ -f "$tmp_dir/acceptance_criteria" ] && acceptance_criteria=$(sed '/./,$!d' "$tmp_dir/acceptance_criteria" | sed -e ':a' -e '/^[[:space:]]*$/{' -e '$d' -e 'N' -e 'ba' -e '}')
 
     safe_path "$tmp_dir" "tmp_dir" || return 1
     rm -rf "$tmp_dir"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Tests for install.sh rsync behavior
+#
+# Verifies that:
+# - Expected directories are copied correctly
+# - Generated artifacts (.venv, __pycache__, etc.) are excluded
+# - Symlinks inside .venv do not cause failures
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WIGGUM_HOME="$(dirname "$TESTS_DIR")"
+
+source "$TESTS_DIR/test-framework.sh"
+
+SRC_DIR=""
+TARGET_DIR=""
+
+setup() {
+    SRC_DIR=$(mktemp -d)
+    TARGET_DIR=$(mktemp -d)
+
+    mkdir -p "$SRC_DIR/bin"
+    echo '#!/bin/bash' > "$SRC_DIR/bin/wiggum"
+    chmod +x "$SRC_DIR/bin/wiggum"
+
+    mkdir -p "$SRC_DIR/lib/core"
+    echo 'echo core' > "$SRC_DIR/lib/core/logger.sh"
+
+    mkdir -p "$SRC_DIR/lib/orchestrator-py"
+    echo '[project]' > "$SRC_DIR/lib/orchestrator-py/pyproject.toml"
+    echo 'main.py' > "$SRC_DIR/lib/orchestrator-py/main.py"
+
+    mkdir -p "$SRC_DIR/config"
+    echo '{}' > "$SRC_DIR/config/config.json"
+
+    mkdir -p "$SRC_DIR/tui"
+    echo '[project]' > "$SRC_DIR/tui/pyproject.toml"
+    echo 'app.py' > "$SRC_DIR/tui/app.py"
+
+    mkdir -p "$SRC_DIR/hooks/callbacks"
+    echo '#!/bin/bash' > "$SRC_DIR/hooks/callbacks/on-done.sh"
+
+    mkdir -p "$SRC_DIR/skills"
+    echo 'skill' > "$SRC_DIR/skills/README.md"
+
+    # Artifacts that should be excluded
+    mkdir -p "$SRC_DIR/tui/.venv/bin"
+    ln -s /usr/bin/python3 "$SRC_DIR/tui/.venv/bin/python3"
+    echo 'fake' > "$SRC_DIR/tui/.venv/pyvenv.cfg"
+
+    mkdir -p "$SRC_DIR/lib/orchestrator-py/.venv/bin"
+    ln -s /usr/bin/python3 "$SRC_DIR/lib/orchestrator-py/.venv/bin/python3"
+
+    mkdir -p "$SRC_DIR/tui/__pycache__"
+    echo 'bytecode' > "$SRC_DIR/tui/__pycache__/app.cpython-312.pyc"
+
+    mkdir -p "$SRC_DIR/lib/orchestrator-py/__pycache__"
+    echo 'bytecode' > "$SRC_DIR/lib/orchestrator-py/__pycache__/main.cpython-312.pyc"
+
+    mkdir -p "$SRC_DIR/tui/tui.egg-info"
+    echo 'metadata' > "$SRC_DIR/tui/tui.egg-info/PKG-INFO"
+
+    mkdir -p "$SRC_DIR/tui/.pytest_cache/v/cache"
+    echo '{}' > "$SRC_DIR/tui/.pytest_cache/v/cache/lastfailed"
+}
+
+teardown() {
+    [[ -n "$SRC_DIR" ]] && rm -rf "$SRC_DIR"
+    [[ -n "$TARGET_DIR" ]] && rm -rf "$TARGET_DIR"
+}
+
+_run_install_rsync() {
+    rsync -a \
+        --exclude '.venv' \
+        --exclude '__pycache__' \
+        --exclude '*.egg-info' \
+        --exclude '.pytest_cache' \
+        "$SRC_DIR/bin" \
+        "$SRC_DIR/lib" \
+        "$SRC_DIR/hooks" \
+        "$SRC_DIR/skills" \
+        "$SRC_DIR/config" \
+        "$SRC_DIR/tui" \
+        "$TARGET_DIR/"
+}
+
+_assert_dir_not_exists() {
+    local dir_path="$1"
+    local message="${2:-Directory should not exist: $dir_path}"
+
+    ASSERTION_COUNT=$((ASSERTION_COUNT + 1))
+
+    if [[ ! -d "$dir_path" ]]; then
+        echo -e "  ${GREEN}✓${NC} $message"
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $message" >&2
+        echo -e "    ${RED}Directory exists: $dir_path${NC}" >&2
+        FAILED_ASSERTIONS=$((FAILED_ASSERTIONS + 1))
+        return 1
+    fi
+}
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+test_rsync_copies_expected_directories() {
+    _run_install_rsync
+
+    assert_dir_exists "$TARGET_DIR/bin" "bin/ should be copied"
+    assert_dir_exists "$TARGET_DIR/lib" "lib/ should be copied"
+    assert_dir_exists "$TARGET_DIR/lib/core" "lib/core/ should be copied"
+    assert_dir_exists "$TARGET_DIR/lib/orchestrator-py" "lib/orchestrator-py/ should be copied"
+    assert_dir_exists "$TARGET_DIR/hooks" "hooks/ should be copied"
+    assert_dir_exists "$TARGET_DIR/hooks/callbacks" "hooks/callbacks/ should be copied"
+    assert_dir_exists "$TARGET_DIR/skills" "skills/ should be copied"
+    assert_dir_exists "$TARGET_DIR/config" "config/ should be copied"
+    assert_dir_exists "$TARGET_DIR/tui" "tui/ should be copied"
+}
+
+test_rsync_copies_file_contents() {
+    _run_install_rsync
+
+    assert_file_exists "$TARGET_DIR/bin/wiggum" "bin/wiggum should be copied"
+    assert_file_exists "$TARGET_DIR/lib/core/logger.sh" "lib/core/logger.sh should be copied"
+    assert_file_exists "$TARGET_DIR/lib/orchestrator-py/pyproject.toml" "orchestrator-py/pyproject.toml should be copied"
+    assert_file_exists "$TARGET_DIR/lib/orchestrator-py/main.py" "orchestrator-py/main.py should be copied"
+    assert_file_exists "$TARGET_DIR/config/config.json" "config/config.json should be copied"
+    assert_file_exists "$TARGET_DIR/tui/pyproject.toml" "tui/pyproject.toml should be copied"
+    assert_file_exists "$TARGET_DIR/tui/app.py" "tui/app.py should be copied"
+    assert_file_exists "$TARGET_DIR/hooks/callbacks/on-done.sh" "hooks callback should be copied"
+    assert_file_exists "$TARGET_DIR/skills/README.md" "skills/README.md should be copied"
+}
+
+test_rsync_excludes_venv() {
+    _run_install_rsync
+
+    _assert_dir_not_exists "$TARGET_DIR/tui/.venv" "tui/.venv should NOT be copied"
+    _assert_dir_not_exists "$TARGET_DIR/lib/orchestrator-py/.venv" "orchestrator-py/.venv should NOT be copied"
+}
+
+test_rsync_excludes_pycache() {
+    _run_install_rsync
+
+    _assert_dir_not_exists "$TARGET_DIR/tui/__pycache__" "tui/__pycache__ should NOT be copied"
+    _assert_dir_not_exists "$TARGET_DIR/lib/orchestrator-py/__pycache__" "orchestrator-py/__pycache__ should NOT be copied"
+}
+
+test_rsync_excludes_egg_info() {
+    _run_install_rsync
+
+    _assert_dir_not_exists "$TARGET_DIR/tui/tui.egg-info" "tui.egg-info should NOT be copied"
+}
+
+test_rsync_excludes_pytest_cache() {
+    _run_install_rsync
+
+    _assert_dir_not_exists "$TARGET_DIR/tui/.pytest_cache" ".pytest_cache should NOT be copied"
+}
+
+test_rsync_idempotent() {
+    _run_install_rsync
+    _run_install_rsync
+
+    assert_file_exists "$TARGET_DIR/bin/wiggum" "bin/wiggum should still exist after second rsync"
+    _assert_dir_not_exists "$TARGET_DIR/tui/.venv" ".venv should still be excluded after second rsync"
+}
+
+test_rsync_exit_code() {
+    local exit_code=0
+    _run_install_rsync || exit_code=$?
+
+    assert_equals "0" "$exit_code" "rsync should exit 0"
+}
+
+# =============================================================================
+# Run
+# =============================================================================
+
+run_test test_rsync_copies_expected_directories
+run_test test_rsync_copies_file_contents
+run_test test_rsync_excludes_venv
+run_test test_rsync_excludes_pycache
+run_test test_rsync_excludes_egg_info
+run_test test_rsync_excludes_pytest_cache
+run_test test_rsync_idempotent
+run_test test_rsync_exit_code
+
+print_test_summary
+exit_with_test_result

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -8,7 +8,6 @@ set -euo pipefail
 # - Symlinks inside .venv do not cause failures
 
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WIGGUM_HOME="$(dirname "$TESTS_DIR")"
 
 source "$TESTS_DIR/test-framework.sh"
 

--- a/tests/test_workspace_hooks.sh
+++ b/tests/test_workspace_hooks.sh
@@ -654,12 +654,16 @@ test_worktree_still_blocks_unrelated_paths() {
 }
 
 test_non_worktree_blocks_external_repo_path() {
-    # Regular workspace (not a worktree) should NOT allow external repo paths
+    # Regular workspace (not a worktree) should NOT allow external repo paths.
+    # Use a nested workspace structure matching real layout so the inferred
+    # worker_dir_abs is specific (not /tmp which would match everything).
     local external_repo
     external_repo=$(mktemp -d)
 
+    local nested_ws="$TEST_WORKSPACE/ralph/workers/worker-TEST/workspace"
+    mkdir -p "$nested_ws"
     local resolved_ws
-    resolved_ws=$(realpath "$TEST_WORKSPACE")
+    resolved_ws=$(realpath "$nested_ws")
 
     local json
     json=$(tool_json "Read" "$external_repo/file.txt")

--- a/tests/test_workspace_hooks.sh
+++ b/tests/test_workspace_hooks.sh
@@ -600,7 +600,7 @@ _teardown_worktree_env() {
     fi
 }
 
-test_worktree_glob_allows_original_repo_path() {
+test_worktree_blocks_original_repo_glob() {
     _setup_worktree_env
 
     local json
@@ -609,12 +609,12 @@ test_worktree_glob_allows_original_repo_path() {
 
     local rc=0
     run_validate_hook "$json" "$_WT_WORKTREE_DIR" "" || rc=$?
-    assert_equals "0" "$rc" "Glob on original repo path should be allowed from worktree"
+    assert_equals "2" "$rc" "Glob on original repo path should be blocked from worktree"
 
     _teardown_worktree_env
 }
 
-test_worktree_read_allows_original_repo_file() {
+test_worktree_blocks_original_repo_read() {
     _setup_worktree_env
 
     local json
@@ -622,12 +622,12 @@ test_worktree_read_allows_original_repo_file() {
 
     local rc=0
     run_validate_hook "$json" "$_WT_WORKTREE_DIR" "" || rc=$?
-    assert_equals "0" "$rc" "Read file in original repo should be allowed from worktree"
+    assert_equals "2" "$rc" "Read file in original repo should be blocked from worktree"
 
     _teardown_worktree_env
 }
 
-test_worktree_write_allows_original_repo_path() {
+test_worktree_blocks_original_repo_write() {
     _setup_worktree_env
 
     local json
@@ -635,7 +635,7 @@ test_worktree_write_allows_original_repo_path() {
 
     local rc=0
     run_validate_hook "$json" "$_WT_WORKTREE_DIR" "" || rc=$?
-    assert_equals "0" "$rc" "Write to original repo path should be allowed from worktree"
+    assert_equals "2" "$rc" "Write to original repo path should be blocked from worktree"
 
     _teardown_worktree_env
 }
@@ -729,10 +729,10 @@ run_test test_hook_allows_grep_inside_workspace
 run_test test_full_integration_setup_then_enforce
 run_test test_full_integration_claude_project_dir_only
 
-# Git worktree path resolution
-run_test test_worktree_glob_allows_original_repo_path
-run_test test_worktree_read_allows_original_repo_file
-run_test test_worktree_write_allows_original_repo_path
+# Git worktree path resolution (original repo must be blocked)
+run_test test_worktree_blocks_original_repo_glob
+run_test test_worktree_blocks_original_repo_read
+run_test test_worktree_blocks_original_repo_write
 run_test test_worktree_still_blocks_unrelated_paths
 run_test test_non_worktree_blocks_external_repo_path
 


### PR DESCRIPTION
Fix three macOS compatibility issues that cause installation failures, recurring log noise, and complete worker blockage on Darwin systems.

## 1. install.sh: `cp -r` Permission denied on .venv symlinks

- Replace `cp -r` with `rsync -a --exclude` to skip non-portable artifacts (`.venv`, `__pycache__`, `*.egg-info`, `.pytest_cache`)
- Add `rsync` to dependency check; add generic `setup_python_env()` for both TUI and orchestrator-py
- macOS `cp -r` dereferences symlinks and fails overwriting `.venv/bin/python*` targets

## 2. issue-parser.sh: GNU sed block syntax incompatible with BSD sed

- Split `sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }'` into separate `-e` expressions per POSIX spec
- BSD sed requires each command in a `{ }` block on its own line; multiple `-e` flags achieve this
- Fixes 6× `unexpected EOF (pending }'s)` errors per PR sync cycle (~2 min interval)

## 3. Worker planning agent blocked by workspace hook in git worktree

- Set `CLAUDE_PROJECT_DIR=$PWD` in `runtime_backend_invoke()` so Claude Code uses the worktree path instead of resolving back to the original repo via `.git` file
- Add worktree detection in `validate-workspace-path.sh`: when workspace is a git worktree, allow paths under the original repository as a fallback safety net
- Without this fix, agents burn their entire turn budget (~73 turns, ~$0.75) unable to access any file

## Changed Files

| File | Change |
|------|--------|
| `install.sh` | `cp -r` → `rsync -a --exclude`, add `setup_python_env()` |
| `lib/github/issue-parser.sh` | POSIX-compatible `sed` multi `-e` syntax (4 call sites) |
| `lib/backend/claude/claude-backend.sh` | Set `CLAUDE_PROJECT_DIR=$PWD` in `runtime_backend_invoke()` |
| `hooks/callbacks/validate-workspace-path.sh` | Worktree detection + original repo path allowance |
| `tests/test_install.sh` | New: 8 test cases for rsync behavior |
| `tests/test_workspace_hooks.sh` | New: 5 test cases for worktree path resolution |

## Test Plan

- [x] `bash tests/test_install.sh` — 8 tests pass (macOS + Linux CI)
- [x] `bash tests/test_issue_parser.sh` — 25 tests, 45 assertions pass (macOS, previously `Should extract description` failed)
- [x] `bash tests/test_workspace_hooks.sh` — worktree section: 5 tests pass (macOS + Linux CI)
- [x] `./tests/run-shellcheck.sh` — all modified files pass
- [x] GitHub Actions CI on ubuntu-latest — all suites pass